### PR TITLE
generate metrics-ingester-certificate only if tls enabled

### DIFF
--- a/charts/groundcover/templates/metrics-ingester/certificate.yaml
+++ b/charts/groundcover/templates/metrics-ingester/certificate.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.metrics.tls.enabled -}}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
@@ -9,3 +10,4 @@ metadata:
 stringData:
   tls.key: {{ $ca.Key  | quote }}
   tls.crt: {{ $ca.Cert | quote }}
+{{ end -}}


### PR DESCRIPTION
add 
`if .Values.global.metrics.tls.enabled`
for tls secret generation. It is generated each time for tls disabled, and not very suitable for gitops way (via ArgoCD for example)