### PR TITLE
[PLAT-579] Limit revisionHistoryLimit to reduce dangling ReplicaSets

### DIFF
--- a/charts/groundcover/charts/opentelemetry-collector/values.yaml
+++ b/charts/groundcover/charts/opentelemetry-collector/values.yaml
@@ -400,7 +400,7 @@ schedulerName: ""
 replicaCount: 1
 
 # only used with deployment mode
-revisionHistoryLimit: 10
+revisionHistoryLimit: 2
 
 annotations: {}
 


### PR DESCRIPTION
Updated revisionHistoryLimit from 10 to 2 to prevent accumulation of old ReplicaSets for the OpenTelemetry Collector, reducing cluster clutter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Reduced the deployment revision history limit from 10 to 2 for the OpenTelemetry Collector chart. This lowers resource usage and cleanup overhead, resulting in a smaller cluster storage footprint and potentially faster Helm operations. Note: Rollback options are now limited to the two most recent revisions, which may affect how far back you can revert deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->