### PR TITLE
Allow config secret name override

### DIFF
--- a/charts/groundcover/templates/_helpers.tpl
+++ b/charts/groundcover/templates/_helpers.tpl
@@ -69,7 +69,7 @@ Create the name of the service account to use
 
 
 {{- define "groundcover.config.secretName" -}}
-{{- printf "%s" (default "groundcover-config" .Values.global.customerConfigOverrides.configSecretName) -}}
+{{- print "groundcover-config" -}}
 {{- end -}}
 
 {{/*
@@ -79,6 +79,9 @@ Get cluster_id from values or generate random one
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "groundcover.config.secretName" .) | default dict) -}}
 {{- if .Values.clusterId -}}
     {{- .Values.clusterId -}}
+{{- else if .Values.global.customerConfigKeysOverrides.enabled -}}
+    {{- $keyName := .Values.global.customerConfigKeysOverrides.mapping.gc_cluster_id -}}
+    {{- index .Values $keyName -}}
 {{- else if $secret -}}
     {{- index $secret "data" "GC_CLUSTER_ID" | b64dec -}}
 {{- else -}}

--- a/charts/groundcover/values.yaml
+++ b/charts/groundcover/values.yaml
@@ -176,8 +176,13 @@ global:
     overrideUrl: ""
 
   # customerConfigOverrides
-  customerConfigOverrides:
-    configSecretName:
+  customerConfigKeysOverrides:
+    enabled: false
+    mapping:
+      gc_cluster_id:
+      gc_region:
+      gc_version:
+      gc_env:
 
 tags:
   # InCloud - Enterprise Setup. groundcover's control-plane reconciled observability infrastructure deployment.


### PR DESCRIPTION
#  Description:

  This PR enables customers to override specific groundcover configuration values through Helm values, providing flexibility for
  custom deployments while maintaining backward compatibility.

##  Changes

  Config Value Overrides

  Modified templates/config.yaml to support customer overrides for core configuration values:
  - GC_CLUSTER_ID - Override cluster identifier
  - GC_REGION - Override deployment region
  - GC_VERSION - Override groundcover version
  - GC_ENV - Override environment (e.g., production, staging)

  Each value uses a fallback pattern: customer override → default helper function → chart default

  Template Updates

  - templates/config.yaml: Updated all config values to check customerConfigOverrides first, then fall back to existing helper
  templates
  - templates/_helpers.tpl: Kept groundcover.config.secretName hardcoded to "groundcover-config" (removed configSecretName override)
  - values.yaml: Added customerConfigOverrides structure with four override fields

###  Configuration Example

```
  global:
    customerConfigKeysOverrides:
      enabled: false
      mapping:
        gc_cluster_id:
        gc_region:
        gc_version:
        gc_env:
```

###  Behavior

  - When override is provided: Uses the customer-specified value
  - When override is empty/null: Falls back to existing helper template logic (e.g., groundcover.clusterId, groundcover.region)
  - Backward compatible: Existing deployments without overrides continue to work unchanged
  - Secret name: Always uses "groundcover-config" (not configurable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support to derive cluster ID from a configurable keys mapping when enabled, taking priority after an explicit value and before secret fallback.
  * Introduced a customerConfigKeysOverrides block in values, with an enabled flag and key mappings for cluster ID, region, version, and environment. Disabled by default for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->