### PR TITLE
refactor(agent): Make sensor DaemonSet updateStrategy configurable

### DIFF
--- a/charts/groundcover/templates/agent/daemonset.yaml
+++ b/charts/groundcover/templates/agent/daemonset.yaml
@@ -22,9 +22,11 @@ metadata:
     {{- end }}
 spec:
   updateStrategy:
-    type: RollingUpdate
+    type: {{ .Values.agent.updateStrategy.type }}
+    {{- if eq .Values.agent.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: 100%
+      maxUnavailable: {{ .Values.agent.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       app: sensor

--- a/charts/groundcover/values.yaml
+++ b/charts/groundcover/values.yaml
@@ -3401,7 +3401,7 @@ vector:
             - logs_to_events_transform
             endpoint: '{{ include "clickhouse.shard0HttpEndpoint" . }}'
             database: "groundcover"
-            table: "events_v2"
+            table: "events_v3"
             request:
               retry_attempts: 5
             auth:

--- a/charts/groundcover/values.yaml
+++ b/charts/groundcover/values.yaml
@@ -412,6 +412,10 @@ agent:
   podLabels:
   additionalAnnotations:
   podAnnotations:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
   tolerations:
   - operator: "Exists"
   affinity:
@@ -3397,7 +3401,7 @@ vector:
             - logs_to_events_transform
             endpoint: '{{ include "clickhouse.shard0HttpEndpoint" . }}'
             database: "groundcover"
-            table: "events_v3"
+            table: "events_v2"
             request:
               retry_attempts: 5
             auth:


### PR DESCRIPTION
Adds support for configuring the sensor DaemonSet updateStrategy via values.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent DaemonSet update strategy is now configurable through Helm values, allowing customization of rollout behavior.

* **Changes**
  * Default agent update strategy set to RollingUpdate with maxUnavailable configured to 100% (can be adjusted via Helm values).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/groundcover-com/helm-charts/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->